### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -19,7 +19,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,17 @@
-<phpunit colors="true" forceCoversAnnotation="true">
-    <testsuites>
-        <testsuite name="TraderInteractive Library Test Suite">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="./clover.xml"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+    <report>
+      <clover outputFile="./clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="TraderInteractive Library Test Suite">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/tests/ConfigurationExceptionTest.php
+++ b/tests/ConfigurationExceptionTest.php
@@ -12,6 +12,7 @@ final class ConfigurationExceptionTest extends TestCase
 {
     /**
      * @test
+     * @coversNothing
      *
      * @return void
      */

--- a/tests/FilterExceptionTest.php
+++ b/tests/FilterExceptionTest.php
@@ -12,6 +12,7 @@ final class ExceptionTest extends TestCase
 {
     /**
      * @test
+     * @coversNothing
      *
      * @return void
      */

--- a/tests/ReadOnlyViolationExceptionTest.php
+++ b/tests/ReadOnlyViolationExceptionTest.php
@@ -12,6 +12,7 @@ final class ReadOnlyViolationExceptionTest extends TestCase
 {
     /**
      * @test
+     * @coversNothing
      *
      * @return void
      */


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove Support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
